### PR TITLE
Improve safety of sd writing

### DIFF
--- a/mode5.cpp
+++ b/mode5.cpp
@@ -198,6 +198,8 @@ void sensor_triggered() {
       buzzer.beep();
     } else {
       buzzer.failure();
+      display.sd();
+      delay(2000);
     }
   }
   print_data_to_log(data);

--- a/recording.cpp
+++ b/recording.cpp
@@ -89,8 +89,6 @@ bool print_racer_data_to_sd(int racer_number, TimeResult data, bool fault) {
 
 void print_data_to_log(TimeResult data, bool fault) {
   #define FILENAME_LENGTH 35
-  char filename[FILENAME_LENGTH];
-  char full_string[FILENAME_LENGTH];
   char data_string[FILENAME_LENGTH];
   snprintf(data_string, FILENAME_LENGTH, "sensor: %2d,%02d,%02d,%03d,%d", data.hour, data.minute, data.second, data.millisecond, fault);
   log(data_string);

--- a/uni_sd.h
+++ b/uni_sd.h
@@ -13,6 +13,7 @@ class UniSd
     bool clearFile(const char *filename);
     bool writeFile(const char *filename, char *text);
     bool readFile(const char *filename, char *result, int max_result);
+    bool testWrite();
   private:
     int _cs;
     bool _status;


### PR DESCRIPTION
Make it more obvious (and less data-losing) if the SD card is unable to be written.
Displays "SD" if a write fails.
Also attempt to write/read to the SD card before each other write attempt, for safety.